### PR TITLE
Fix duplicate link in footer navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,15 +441,6 @@
               >Report an Issue</a
             >
           </li>
-          <li>
-            <a href="https://github.com/Liphip/expense_tracker/issues/new">Report an Issue</a>
-          </li>
-          <li>
-            <a href="https://github.com/Liphip/expense_tracker/issues/new">Report an Issue</a>
-          </li>
-          <li>
-            <a href="https://github.com/Liphip/expense_tracker/issues/new">Report an Issue</a>
-          </li>
         </ul>
       </nav>
     </footer>


### PR DESCRIPTION
Remove duplicate "Report an Issue" links from the footer navigation to streamline the user interface.